### PR TITLE
enable CRFM API return completion objects in OpenAI's format; fixes #13 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ dmypy.json
 
 # API keys
 .crfm_api_key
+
+# playground
+znote.py

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ dmypy.json
 
 # Latex
 *.bib
+
+# API keys
+.crfm_api_key

--- a/ml_swissknife/crfm_utils.py
+++ b/ml_swissknife/crfm_utils.py
@@ -5,15 +5,46 @@ import time
 from typing import Optional, Sequence, Union
 
 import fire
+import helm.common.request
 from helm.common.authentication import Authentication
 from helm.common.request import Request, RequestResult
+from helm.proxy.accounts import Account
 from helm.proxy.models import MODEL_NAME_TO_MODEL
 from helm.proxy.services.remote_service import RemoteService
-from helm.proxy.accounts import Account
+from openai import openai_object
 
 from . import openai_utils
+from .types import StrOrCompletionObject
 
 crfm_model_names = tuple(MODEL_NAME_TO_MODEL.keys())
+
+
+def convert_dict_to_openai_object(data: dict) -> openai_object.OpenAIObject:
+    return_data = openai_object.OpenAIObject()
+    return_data.update(data)
+    return return_data
+
+
+def convert_crfm_object_to_openai_object(
+    data: helm.common.request.Sequence,
+) -> openai_object.OpenAIObject:
+    """Convert helm.common.request.Sequence object to openai_object.OpenAIObject object."""
+    return_data = convert_dict_to_openai_object(
+        dict(
+            text=data.text,
+            logprobs=convert_dict_to_openai_object(
+                dict(
+                    tokens=[token.text for token in data.tokens],
+                    top_logprobs=[
+                        convert_dict_to_openai_object(token.top_logprobs)
+                        for token in data.tokens
+                    ],
+                    token_logprobs=[token.logprob for token in data.tokens],
+                )
+            ),
+        )
+    )
+    return return_data
 
 
 def normalize_model_name(model_name):
@@ -41,11 +72,31 @@ def crfm_completion(
     sleep_time=2,
     max_instances=sys.maxsize,
     return_text=False,  # Return text instead of full completion object (which contains things like logprob).
+    return_openai_object=False,  # Return objects in the OpenAI format.
     crfm_api_key: Optional[str] = None,
     random: Optional[str] = None,
     **unused_kwargs,
-):
-    """Mirrors `openai_utils._openai_completion`."""
+) -> Union[StrOrCompletionObject, Sequence[StrOrCompletionObject]]:
+    """Mirrors `openai_utils._openai_completion`.
+
+    Args:
+        prompts: A string or a list of strings to complete.
+        decoding_args: Decoding arguments.
+        model_name: Model name. Can be either in the format of "org/model" or just "model".
+        sleep_time: Time to sleep once the rate-limit is hit.
+        max_instances: Maximum number of prompts to decode.
+        return_text: If True, return text instead of full completion object (which contains things like logprob).
+        return_openai_object: If True and not return_text, return objects in the OpenAI (opposed to CRFM) format.
+        crfm_api_key: CRFM API key.
+        random: Random seed.
+
+    Returns:
+        A completion or a list of completions.
+        Depending on return_text and return_openai_object, the completion type can be one of
+            - a string (if return_text is True)
+            - a helm.common.request.Sequence object (if return_text is False and return_openai_object is False)
+            - an openai_object.OpenAIObject object (if return_text is False and return_openai_object is True)
+    """
     crfm_api_key = os.getenv("CRFM_API_KEY") if crfm_api_key is None else crfm_api_key
     auth = Authentication(api_key=crfm_api_key)
     service = RemoteService("https://crfm-models.stanford.edu")
@@ -73,6 +124,7 @@ def crfm_completion(
                     top_p=decoding_args.top_p,
                     presence_penalty=decoding_args.presence_penalty,
                     frequency_penalty=decoding_args.frequency_penalty,
+                    top_k_per_token=decoding_args.logprobs,
                     random=random,
                 )
                 request_result: RequestResult = service.make_request(auth, request)
@@ -82,6 +134,11 @@ def crfm_completion(
                 logging.warning(f"Original exception: {e}.")
                 logging.warning(f"Retrying request after {sleep_time} seconds.")
                 time.sleep(sleep_time)  # Annoying rate limit on requests.
+    if return_openai_object:
+        completions = [
+            convert_crfm_object_to_openai_object(completion)
+            for completion in completions
+        ]
     if return_text:
         completions = [completion.text for completion in completions]
     if decoding_args.n > 1:
@@ -97,9 +154,10 @@ def crfm_completion(
 
 
 def main(**kwargs):
+    # python -m ml_swissknife.crfm_utils
     out = crfm_completion(
         prompts=["Life is"],
-        decoding_args=openai_utils.OpenAIDecodingArguments(n=2),
+        decoding_args=openai_utils.OpenAIDecodingArguments(n=2, logprobs=1),
         return_text=True,
         random="1000",
     )

--- a/ml_swissknife/crfm_utils.py
+++ b/ml_swissknife/crfm_utils.py
@@ -91,9 +91,8 @@ def crfm_completion(
             for i in range(0, len(completions), decoding_args.n)
         ]
     if is_single_prompt:
-        (
-            completions,
-        ) = completions  # Return non-tuple if only 1 input and 1 generation.
+        # Return non-tuple if only 1 input and 1 generation.
+        (completions,) = completions
     return completions
 
 

--- a/ml_swissknife/crfm_utils.py
+++ b/ml_swissknife/crfm_utils.py
@@ -76,8 +76,8 @@ def crfm_completion(
     model_name="text-davinci-003",
     sleep_time=2,
     max_instances=sys.maxsize,
-    return_text=False,  # Return text instead of full completion object (which contains things like logprob).
-    return_openai_object=True,  # Return objects in the OpenAI format.
+    return_text=False,
+    return_openai_object=True,
     crfm_api_key: Optional[str] = None,
     random: Optional[str] = None,
     **unused_kwargs,
@@ -120,6 +120,7 @@ def crfm_completion(
     prompts = prompts[:max_instances]
     model_name = normalize_model_name(model_name)
     stop_sequences = [] if decoding_args.stop is None else list(decoding_args.stop)
+    top_k_per_token = 1 if decoding_args.logprobs is None else decoding_args.logprobs
 
     completions = []
     for prompt in tqdm.tqdm(prompts, desc="prompts", total=len(prompts)):
@@ -136,9 +137,7 @@ def crfm_completion(
                     top_p=decoding_args.top_p,
                     presence_penalty=decoding_args.presence_penalty,
                     frequency_penalty=decoding_args.frequency_penalty,
-                    top_k_per_token=1
-                    if decoding_args.logprobs is None
-                    else decoding_args.logprobs,
+                    top_k_per_token=top_k_per_token,
                     random=random,
                 )
                 request_result: RequestResult = service.make_request(auth, request)

--- a/ml_swissknife/crfm_utils.py
+++ b/ml_swissknife/crfm_utils.py
@@ -101,10 +101,11 @@ def crfm_completion(
 
     Returns:
         A completion or a list of completions.
-        Depending on return_text and return_openai_object, the completion type can be one of
+        Depending on return_text, return_openai_object, and decoding_args.n, the completion type can be one of
             - a string (if return_text is True)
             - a helm.common.request.Sequence object (if return_text is False and return_openai_object is False)
             - an openai_object.OpenAIObject object (if return_text is False and return_openai_object is True)
+            - a list of objects of the above types (if decoding_args.n > 1)
     """
     utils.handle_unused_kwargs(unused_kwargs, msg="crfm_completion")
 

--- a/ml_swissknife/crfm_utils.py
+++ b/ml_swissknife/crfm_utils.py
@@ -6,6 +6,7 @@ from typing import Optional, Sequence, Union
 
 import fire
 import helm.common.request
+import tqdm
 from helm.common.authentication import Authentication
 from helm.common.request import Request, RequestResult
 from helm.proxy.accounts import Account
@@ -13,8 +14,12 @@ from helm.proxy.models import MODEL_NAME_TO_MODEL
 from helm.proxy.services.remote_service import RemoteService
 from openai import openai_object
 
+from ml_swissknife import utils
 from . import openai_utils
-from .types import StrOrCompletionObject
+
+StrOrCompletionObject = Union[
+    str, openai_object.OpenAIObject, helm.common.request.Sequence
+]
 
 crfm_model_names = tuple(MODEL_NAME_TO_MODEL.keys())
 
@@ -72,11 +77,15 @@ def crfm_completion(
     sleep_time=2,
     max_instances=sys.maxsize,
     return_text=False,  # Return text instead of full completion object (which contains things like logprob).
-    return_openai_object=False,  # Return objects in the OpenAI format.
+    return_openai_object=True,  # Return objects in the OpenAI format.
     crfm_api_key: Optional[str] = None,
     random: Optional[str] = None,
     **unused_kwargs,
-) -> Union[StrOrCompletionObject, Sequence[StrOrCompletionObject]]:
+) -> Union[
+    StrOrCompletionObject,
+    Sequence[StrOrCompletionObject],
+    Sequence[Sequence[StrOrCompletionObject]],
+]:
     """Mirrors `openai_utils._openai_completion`.
 
     Args:
@@ -97,6 +106,8 @@ def crfm_completion(
             - a helm.common.request.Sequence object (if return_text is False and return_openai_object is False)
             - an openai_object.OpenAIObject object (if return_text is False and return_openai_object is True)
     """
+    utils.handle_unused_kwargs(unused_kwargs, msg="crfm_completion")
+
     crfm_api_key = os.getenv("CRFM_API_KEY") if crfm_api_key is None else crfm_api_key
     auth = Authentication(api_key=crfm_api_key)
     service = RemoteService("https://crfm-models.stanford.edu")
@@ -110,7 +121,7 @@ def crfm_completion(
     stop_sequences = [] if decoding_args.stop is None else list(decoding_args.stop)
 
     completions = []
-    for prompt in prompts:
+    for prompt in tqdm.tqdm(prompts, desc="prompts", total=len(prompts)):
         while True:
             try:
                 request = Request(
@@ -124,7 +135,9 @@ def crfm_completion(
                     top_p=decoding_args.top_p,
                     presence_penalty=decoding_args.presence_penalty,
                     frequency_penalty=decoding_args.frequency_penalty,
-                    top_k_per_token=decoding_args.logprobs,
+                    top_k_per_token=1
+                    if decoding_args.logprobs is None
+                    else decoding_args.logprobs,
                     random=random,
                 )
                 request_result: RequestResult = service.make_request(auth, request)
@@ -157,11 +170,15 @@ def main(**kwargs):
     # python -m ml_swissknife.crfm_utils
     out = crfm_completion(
         prompts=["Life is"],
-        decoding_args=openai_utils.OpenAIDecodingArguments(n=2, logprobs=1),
-        return_text=True,
-        random="1000",
+        decoding_args=openai_utils.OpenAIDecodingArguments(n=1, logprobs=3),
+        return_text=False,
+        return_openai_object=True,
+        random="2000",
     )
-    print(out)
+    print(out[0].logprobs.top_logprobs)
+    print(out[0].logprobs.tokens)
+    print(out[0].logprobs.token_logprobs)
+    breakpoint()
     out = crfm_completion(
         prompts="Life is",
         decoding_args=openai_utils.OpenAIDecodingArguments(n=2),

--- a/ml_swissknife/openai_utils.py
+++ b/ml_swissknife/openai_utils.py
@@ -63,10 +63,23 @@ def _openai_completion(
 ]:
     """Decode with OpenAI API.
 
-    If prompts is a string, returns a single completion object (which may contain things like logprob).
-    If prompts is a sequence, returns a list of completions objects.
-    If return_text is True, the completion objects are all strings.
-    If decoding_args.n > 1, returns a nested list, where each entry is a list of completion objects for the same prompt.
+    Args:
+        prompts: A string or a list of strings to complete.
+        decoding_args: Decoding arguments.
+        model_name: Model name. Can be either in the format of "org/model" or just "model".
+        sleep_time: Time to sleep once the rate-limit is hit.
+        batch_size: Number of prompts to send in a single request.
+        max_instances: Maximum number of prompts to decode.
+        max_batches: Maximum number of batches to decode. This argument will be deprecated in the future.
+        return_text: If True, return text instead of full completion object (which contains things like logprob).
+        decoding_kwargs: Additional decoding arguments. Pass in `best_of` and `logit_bias` if you need them.
+
+    Returns:
+        A completion or a list of completions.
+        Depending on return_text, return_openai_object, and decoding_args.n, the completion type can be one of
+            - a string (if return_text is True)
+            - an openai_object.OpenAIObject object (if return_text is False)
+            - a list of objects of the above types (if decoding_args.n > 1)
     """
     is_single_prompt = isinstance(prompts, str)
     if is_single_prompt:
@@ -77,8 +90,8 @@ def _openai_completion(
             "`max_batches` will be deprecated in the future, please use `max_instances` instead."
             "Setting `max_instances` to `max_batches * batch_size` for now."
         )
+        max_instances = max_batches * batch_size
 
-    max_instances = min(max_instances, max_batches * batch_size)
     prompts = prompts[:max_instances]
     num_prompts = len(prompts)
     prompt_batches = [

--- a/ml_swissknife/openai_utils.py
+++ b/ml_swissknife/openai_utils.py
@@ -54,7 +54,7 @@ def _openai_completion(
     batch_size=1,
     max_instances=sys.maxsize,
     max_batches=sys.maxsize,
-    return_text=False,  # Return text instead of full completion object (which contains things like logprob).
+    return_text=False,
     **decoding_kwargs,
 ) -> Union[
     Union[StrOrOpenAIObject],

--- a/ml_swissknife/openai_utils.py
+++ b/ml_swissknife/openai_utils.py
@@ -118,9 +118,8 @@ def _openai_completion(
             for i in range(0, len(completions), decoding_args.n)
         ]
     if is_single_prompt:
-        (
-            completions,
-        ) = completions  # Return non-tuple if only 1 input and 1 generation.
+        # Return non-tuple if only 1 input and 1 generation.
+        (completions,) = completions
     return completions
 
 

--- a/ml_swissknife/openai_utils.py
+++ b/ml_swissknife/openai_utils.py
@@ -16,6 +16,8 @@ from typing import Optional, Sequence, Union
 import openai
 import tqdm
 
+from .types import StrOrOpenAIObject
+
 openai_org = os.getenv("OPENAI_ORG")
 if openai_org is not None:
     openai.organization = openai_org
@@ -51,7 +53,7 @@ def _openai_completion(
     max_batches=sys.maxsize,
     return_text=False,  # Return text instead of full completion object (which contains things like logprob).
     **decoding_kwargs,
-):
+) -> Union[StrOrOpenAIObject, Sequence[StrOrOpenAIObject]]:
     """Decode with OpenAI API.
 
     If prompts is a string, returns a single completion object (which may contain things like logprob).

--- a/ml_swissknife/types.py
+++ b/ml_swissknife/types.py
@@ -13,12 +13,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import io
+import pathlib
 from typing import Union
 
+import helm.common.request
 from openai import openai_object
-import pathlib
-import io
 
 StrOrOpenAIObject = Union[str, openai_object.OpenAIObject]
+StrOrCompletionObject = Union[str, openai_object.OpenAIObject, helm.common.request.Sequence]
 Numeric = Union[int, float]
 PathOrIOBase = Union[str, pathlib.Path, io.IOBase]

--- a/ml_swissknife/types.py
+++ b/ml_swissknife/types.py
@@ -20,7 +20,5 @@ from typing import Union
 import helm.common.request
 from openai import openai_object
 
-StrOrOpenAIObject = Union[str, openai_object.OpenAIObject]
-StrOrCompletionObject = Union[str, openai_object.OpenAIObject, helm.common.request.Sequence]
 Numeric = Union[int, float]
 PathOrIOBase = Union[str, pathlib.Path, io.IOBase]

--- a/ml_swissknife/types.py
+++ b/ml_swissknife/types.py
@@ -1,0 +1,24 @@
+# Copyright (C) Xuechen Li
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Union
+
+from openai import openai_object
+import pathlib
+import io
+
+StrOrOpenAIObject = Union[str, openai_object.OpenAIObject]
+Numeric = Union[int, float]
+PathOrIOBase = Union[str, pathlib.Path, io.IOBase]

--- a/ml_swissknife/utils.py
+++ b/ml_swissknife/utils.py
@@ -45,6 +45,8 @@ from scipy import stats
 from torch import nn, optim
 from torch.utils import data
 
+from .types import Numeric, PathOrIOBase
+
 # Misc.
 home = os.path.expanduser("~")
 home_data = os.path.join(home, "data")
@@ -53,8 +55,6 @@ pathexists = os.path.exists
 makedirs = functools.partial(os.makedirs, exist_ok=True)
 dirname = os.path.dirname
 basename = os.path.basename
-Numeric = Union[int, float]
-PathOrIOBase = Union[str, pathlib.Path, io.IOBase]
 
 
 def float2str(x, precision=8):

--- a/tests/test_crfm_utils.py
+++ b/tests/test_crfm_utils.py
@@ -1,0 +1,36 @@
+from ml_swissknife import crfm_utils, openai_utils
+
+
+def assert_strict_type_match(obj1, obj2, recursive=True, ignore_key_set_mismatch=True, ignore_length_mismatch=True):
+    assert type(obj1) == type(obj2)
+    if recursive:
+        if isinstance(obj1, dict):
+            if not ignore_key_set_mismatch:
+                assert set(obj1.keys()) == set(obj2.keys())
+            for k in obj1.keys():
+                if k in obj2:
+                    assert_strict_type_match(obj1[k], obj2[k], recursive=recursive,
+                                             ignore_key_set_mismatch=ignore_key_set_mismatch)
+        if isinstance(obj1, (list, tuple)):
+            if not ignore_length_mismatch:
+                assert len(obj1) == len(obj2)
+            for x, y in zip(obj1, obj2):
+                assert_strict_type_match(x, y, recursive=recursive, ignore_key_set_mismatch=ignore_key_set_mismatch)
+
+
+def test_crfm_completion():
+    """Test the return format between the two APIs are the same when crfm_completion is forced to do so."""
+    prompts = ["Life is like a box of", "Life is"]
+
+    # Note the types don't match when logprobs=None. CRFM API always gives logprobs, whereas OpenAI API doesn't.
+    single_sample_decoding_args = openai_utils.OpenAIDecodingArguments(logprobs=3)
+    multi_sample_decoding_args = openai_utils.OpenAIDecodingArguments(n=2, logprobs=3)
+
+    for decoding_args in (single_sample_decoding_args, multi_sample_decoding_args):
+        for return_text in (True, False,):
+            crfm_ret = crfm_utils.crfm_completion(
+                prompts, return_text=return_text, decoding_args=decoding_args, return_openai_object=True)
+            openai_ret = openai_utils.openai_completion(
+                prompts, return_text=return_text, decoding_args=decoding_args, batch_size=2)
+            assert_strict_type_match(
+                crfm_ret, openai_ret, recursive=True, ignore_key_set_mismatch=True, ignore_length_mismatch=True)


### PR DESCRIPTION
- `crfm_completion` should (almost) be a drop-in replacement for `openai_completion`. 
- only difference is that `crfm-helm` doesn't have `batch_size` argument. 
- set `return_openai_object=True` to ensure consistency.